### PR TITLE
Added footer support for attachments.

### DIFF
--- a/src/Cake.Slack/Chat/SlackChatMessageAttachment.cs
+++ b/src/Cake.Slack/Chat/SlackChatMessageAttachment.cs
@@ -111,6 +111,22 @@ namespace Cake.Slack.Chat
         public string Thumb_Url { get; set; }
 
         /// <summary>
+        /// Footer text to display in message.
+        /// </summary>
+        /// <value>
+        /// The footer.
+        /// </value>
+        public string Footer { get; set; }
+
+        /// <summary>
+        /// Footer icon to display in message.
+        /// </summary>
+        /// <value>
+        /// The footer_icon.
+        /// </value>
+        public string Footer_Icon { get; set; }
+
+        /// <summary>
         /// Collection of <see cref="SlackChatMessageAttachmentField"/>
         /// </summary>
         /// <value>


### PR DESCRIPTION
Added footer support for attachments as defined in [Slack documentation.](https://api.slack.com/docs/message-attachments)