### PR TITLE
Added support of link_names parameter.

### DIFF
--- a/src/Cake.Slack/Chat/SlackChatApi.cs
+++ b/src/Cake.Slack/Chat/SlackChatApi.cs
@@ -151,8 +151,9 @@ namespace Cake.Slack.Chat
                     username = messageSettings.UserName ?? "CakeBuild",
                     attachments = messageAttachments,
                     icon_url =
-                    messageSettings.IconUrl?.AbsoluteUri ??
-                    "https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-small.png"
+                        messageSettings.IconUrl?.AbsoluteUri ??
+                        "https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-small.png",
+                    link_names = messageSettings.LinkNames.ToString().ToLower(),
                 });
 
             context.Debug("Parameter: {0}", json);
@@ -283,7 +284,8 @@ namespace Cake.Slack.Chat
                     "icon_url",
                     messageSettings.IconUrl?.AbsoluteUri ??
                     "https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-small.png"
-                }
+                },
+                {"link_names", messageSettings.LinkNames.ToString().ToLower()},
             };
 
             if (messageAttachments.Count > 0)

--- a/src/Cake.Slack/Chat/SlackChatMessageSettings.cs
+++ b/src/Cake.Slack/Chat/SlackChatMessageSettings.cs
@@ -36,6 +36,11 @@ namespace Cake.Slack.Chat
         public Uri IconUrl { get; set; }
 
         /// <summary>
+        /// Find and link channel names and usernames.
+        /// </summary>
+        public bool LinkNames { get; set; }
+
+        /// <summary>
         /// Optional flag for if should throw exception on failure
         /// </summary>
         public bool? ThrowOnFail { get; set; }


### PR DESCRIPTION
`Cake.Slack` did not support ability to mention somebody in message by his @slackname. Now it is possible by setting `LinkNames` parameter of `SlackChatMessageSettings` to `true`. It's default value is `false`, so default behavior did not change.