### PR TITLE
(build) Switch to latest Cake.Recipe

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.3.0",
+      "version": "3.2.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,5 +1,5 @@
 #tool dotnet:?package=DPI&version=2021.12.8.49
-#load nuget:https://pkgs.dev.azure.com/cake-contrib/Home/_packaging/addins/nuget/v3/index.json?package=Cake.Recipe&version=4.0.0-alpha0126
+#load nuget:https://pkgs.dev.azure.com/cake-contrib/Home/_packaging/addins/nuget/v3/index.json?package=Cake.Recipe&version=4.1.0-alpha0036
 
 Environment.SetVariableNames();
 
@@ -17,7 +17,7 @@ BuildParameters.PrintParameters(Context);
 ToolSettings.SetToolSettings(context: Context);
 
 Task("DPI")
-    .IsDependeeOf("DotNetCore-Build")
+    .IsDependeeOf("DotNet-Build")
     .Does<BuildVersion>(
         (context, buildVersion) => {
     var result = context.StartProcess(
@@ -46,4 +46,4 @@ Task("DPI")
     }
 });
 
-Build.RunDotNetCore();
+Build.RunDotNet();


### PR DESCRIPTION
This is a little bit "meta" but let's use the latest alpha version of Cake.Recipe to build the current version of Cake.Slack, which "needs" a new version of Cake.Slack, in order to ship the next version of Cake.Recipe: :-)