### PR TITLE
(#60) Add README to nupkg

### DIFF
--- a/src/Cake.Slack/Cake.Slack.csproj
+++ b/src/Cake.Slack/Cake.Slack.csproj
@@ -21,10 +21,12 @@
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
     <PackageReleaseNotes>$(PackageProjectUrl)/releases</PackageReleaseNotes>
     <Version>0.0.0</Version>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="$(ProjectDir)../.editorconfig" Link=".editorconfig" />
+    <None Include="$(ProjectDir)../../README.md" Link="README.md" PackagePath="" Pack="true" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The package page is a little "empty" on nuget.org.  Adding the project readme to the generated nupkg will provide some information on the package page.

Fixes #60 