### PR TITLE
(#66) Bump version of Cake.* used to 5.0.0

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/src/Cake.Slack/Cake.Slack.csproj
+++ b/src/Cake.Slack/Cake.Slack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Cake.Slack</AssemblyName>
     <PackageId>Cake.Slack</PackageId>
@@ -40,9 +40,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Common" Version="4.0.0" PrivateAssets="All" />
-    <PackageReference Include="CakeContrib.Guidelines" Version="1.5.1">
+    <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Common" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="CakeContrib.Guidelines" Version="1.6.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Cake.Slack/Cake.Slack.csproj
+++ b/src/Cake.Slack/Cake.Slack.csproj
@@ -46,7 +46,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Cake.Slack/slack.cake
+++ b/src/Cake.Slack/slack.cake
@@ -1,5 +1,9 @@
-﻿#r "Cake.Slack.dll"
-var slackChannel    = "#cake";
+﻿// Go to https://api.slack.com/apps to get token
+// and WebHookUrl
+// https://api.slack.com/apps/A09JMKFN2UT/incoming-webhooks?
+// https://api.slack.com/apps/A09JMKFN2UT/oauth?
+#r "bin/Release/net9.0/Cake.Slack.dll"
+var slackChannel    = "#cake-contrib";
 var slackToken      = EnvironmentVariable("SLACK_TOKEN");
 var slackhookuri    = EnvironmentVariable("slackhookuri");
 


### PR DESCRIPTION
This "requires" also a bump in the .NET SDK that is used, as as well
the TargetFrameworks.

Fixes #66